### PR TITLE
Replace `warn` function with `@warn` macro

### DIFF
--- a/src/CMakeWrapper.jl
+++ b/src/CMakeWrapper.jl
@@ -102,7 +102,7 @@ function generate_steps(dep::LibraryDependency, h::CMakeProcess, provider_opts)
     haskey(opts,:env) && merge!(env,opts[:env])
     opts[:env] = env
     if get(provider_opts, :force_rebuild, false)
-        warn("force_rebuild option is not supported for CMakeProcess. It will be ignored")
+        @warn "force_rebuild option is not supported for CMakeProcess. It will be ignored"
     end
     steps |= CMakeBuild(; opts...)
     steps


### PR DESCRIPTION
`warn` function does not exist in Julia 1.1